### PR TITLE
Fixes encoder bug with overloaded call to buildMessage

### DIFF
--- a/src/canutil/write.c
+++ b/src/canutil/write.c
@@ -14,7 +14,7 @@ uint64_t float_to_fixed_point(const double value, const float factor,
     return (uint64_t)raw;
 }
 
-uint64_t eightbyte_encode_float(float value, uint8_t bit_offset, uint8_t bit_size,
+uint64_t eightbyte_encode_float(double value, uint8_t bit_offset, uint8_t bit_size,
         float factor, float offset) {
     uint64_t result = 0;
     if(!eightbyte_set_bitfield(float_to_fixed_point(value, factor, offset),

--- a/src/canutil/write.c
+++ b/src/canutil/write.c
@@ -2,9 +2,9 @@
 #include <bitfield/bitfield.h>
 #include <bitfield/8byte.h>
 
-uint64_t float_to_fixed_point(const float value, const float factor,
+uint64_t float_to_fixed_point(const double value, const float factor,
         const float offset) {
-    float raw = (value - offset) / factor;
+    double raw = (value - offset) / factor;
     if(raw > 0) {
         // round up to avoid losing precision when we cast to an int
         // TODO do we need a way to encode an int back to a signal without any
@@ -29,7 +29,7 @@ uint64_t eightbyte_encode_bool(const bool value, const uint8_t bit_offset,
     return eightbyte_encode_float(value, bit_offset, bit_size, 1.0, 0);
 }
 
-bool bitfield_encode_float(const float value, const uint8_t bit_offset,
+bool bitfield_encode_float(const double value, const uint8_t bit_offset,
         const uint8_t bit_size, const float factor, const float offset,
         uint8_t destination[], const uint8_t destination_length) {
     if(!set_bitfield(float_to_fixed_point(value, factor, offset), bit_offset,

--- a/src/canutil/write.h
+++ b/src/canutil/write.h
@@ -23,7 +23,7 @@ extern "C" {
  *
  * Returns a big-endian uint64_t with the value encoded as a bitfield.
  */
-uint64_t eightbyte_encode_float(float value, uint8_t bit_offset,
+uint64_t eightbyte_encode_float(double value, uint8_t bit_offset,
         uint8_t bit_size, float factor, float offset);
 
 uint64_t float_to_fixed_point(const double value, const float factor,

--- a/src/canutil/write.h
+++ b/src/canutil/write.h
@@ -26,10 +26,10 @@ extern "C" {
 uint64_t eightbyte_encode_float(float value, uint8_t bit_offset,
         uint8_t bit_size, float factor, float offset);
 
-uint64_t float_to_fixed_point(const float value, const float factor,
+uint64_t float_to_fixed_point(const double value, const float factor,
         const float offset);
 
-bool bitfield_encode_float(const float value, const uint8_t bit_offset,
+bool bitfield_encode_float(const double value, const uint8_t bit_offset,
         const uint8_t bit_size, const float factor, const float offset,
         uint8_t destination[], const uint8_t destination_length);
 


### PR DESCRIPTION
Encoded value is changed from 32-bit to 64-bit before being written to the CAN.
