### PR TITLE
Fix issues of macro "PREPARE_FIRST_COPY" and bitmask

### DIFF
--- a/src/bitfield/bitarray.c
+++ b/src/bitfield/bitarray.c
@@ -10,13 +10,13 @@
         bit_count -= CHAR_BIT - destination_offset_modulo;                  \
     } else {                                                      \
         *destination &= reverse_mask[destination_offset_modulo]               \
-              | reverse_mask_xor[destination_offset_modulo + bit_count + 1];\
+              | reverse_mask_xor[destination_offset_modulo + bit_count];\
          c &= reverse_mask[destination_offset_modulo + bit_count    ];\
         bit_count = 0;                                              \
     } } while (0)
 
 static const uint8_t reverse_mask[] =
-    { 0x55, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff };
+    { 0x00, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff };
 static const uint8_t reverse_mask_xor[] =
     { 0xff, 0x7f, 0x3f, 0x1f, 0x0f, 0x07, 0x03, 0x01, 0x00 };
 

--- a/src/bitfield/bitfield.c
+++ b/src/bitfield/bitfield.c
@@ -4,8 +4,16 @@
 #include <stddef.h>
 #include <sys/param.h>
 
-uint64_t bitmask(const uint8_t bit_count) {
-    return (((uint64_t)0x1) << bit_count) - 1;
+uint64_t bitmask ( const uint8_t bit_count )
+{
+    if ( 64 == bit_count )
+    {
+        return 0xFFFFFFFFFFFFFFFF;
+    }
+    else
+    {
+        return ( ( ( uint64_t ) 0x1 ) << bit_count ) - 1;
+    }
 }
 
 uint8_t get_nibble(const uint8_t source[], const uint8_t source_length,
@@ -27,7 +35,7 @@ uint8_t get_byte(const uint8_t source[], const uint8_t source_length,
     return 0;
 }
 
-uint64_t get_bitfield(const uint8_t source[], const uint8_t source_length,
+uint64_t get_bitfield(const uint8_t source[], const uint16_t source_length,
                 const uint16_t offset, const uint16_t bit_count) {
     if(bit_count > 64 || bit_count < 1) {
         // TODO error reporting?

--- a/src/bitfield/bitfield.c
+++ b/src/bitfield/bitfield.c
@@ -7,13 +7,9 @@
 uint64_t bitmask ( const uint8_t bit_count )
 {
     if ( 64 == bit_count )
-    {
         return 0xFFFFFFFFFFFFFFFF;
-    }
     else
-    {
         return ( ( ( uint64_t ) 0x1 ) << bit_count ) - 1;
-    }
 }
 
 uint8_t get_nibble(const uint8_t source[], const uint8_t source_length,
@@ -46,7 +42,7 @@ uint64_t get_bitfield(const uint8_t source[], const uint16_t source_length,
     memset(combined.bytes, 0, sizeof(combined.bytes));
     if(copy_bits_right_aligned(source, source_length, offset, bit_count,
             combined.bytes, sizeof(combined.bytes))) {
-        if(BYTE_ORDER == LITTLE_ENDIAN) {
+        if(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
             combined.whole = __builtin_bswap64(combined.whole);
         }
     } else {
@@ -72,7 +68,7 @@ bool set_bitfield(const uint64_t value, const uint16_t offset,
         whole: value
     };
 
-    if(BYTE_ORDER == LITTLE_ENDIAN) {
+    if(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
         combined.whole = __builtin_bswap64(combined.whole);
     }
 

--- a/src/bitfield/bitfield.h
+++ b/src/bitfield/bitfield.h
@@ -37,7 +37,7 @@ extern "C" {
  *
  * Returns the value of the requested bit field, right aligned in a uint64_t.
  */
-uint64_t get_bitfield(const uint8_t source[], const uint8_t source_length,
+uint64_t get_bitfield(const uint8_t source[], const uint16_t source_length,
                 const uint16_t offset, const uint16_t bit_count);
 
 /* Public: Return a single nibble from the byte array, with range checking.

--- a/tests/bitfield_tests.c
+++ b/tests/bitfield_tests.c
@@ -33,6 +33,10 @@ START_TEST (test_set_bitfield)
     fail_unless(set_bitfield(bitmask(3), 10, 3, data, sizeof(data)));
     ck_assert_int_eq(data[0], 0x12);
     ck_assert_int_eq(data[1], 0x38);
+    fail_unless(set_bitfield(0x1, 23, 1, data, sizeof(data)));
+    ck_assert_int_eq(data[2], 0x1);
+    fail_unless(set_bitfield(0x1, 21, 2, data, sizeof(data)));
+    ck_assert_int_eq(data[2], 0x3);
 }
 END_TEST
 
@@ -102,6 +106,14 @@ START_TEST (test_get_uneven_bits)
 }
 END_TEST
 
+START_TEST (test_get_bitfiled)
+{
+    uint8_t data[4] = {0x12, 0x34, 0x56, 0x78};
+    uint64_t result = get_bitfield(data, sizeof(data), 8, 16);
+    ck_assert_int_eq(result, 0x3456);
+}
+END_TEST
+
 Suite* bitfieldSuite(void) {
     Suite* s = suite_create("bitfield");
     TCase *tc_core = tcase_create("core");
@@ -114,6 +126,7 @@ Suite* bitfieldSuite(void) {
     tcase_add_test(tc_core, test_copy_bytes);
     tcase_add_test(tc_core, test_get_bits_out_of_range);
     tcase_add_test(tc_core, test_get_uneven_bits);
+    tcase_add_test(tc_core, test_get_bitfiled);
     suite_add_tcase(s, tc_core);
 
     return s;


### PR DESCRIPTION
1 Fix issue: Bug in macro "PREPARE_FIRST_COPY".
2 Fix function "bitmask" to support 64 bit count.
3 Fix parameter "source_length" type of function "get_bitfield" to uint16_t.
4 Add testcase.