### PR TITLE
Support msvc

### DIFF
--- a/src/bitfield/bitfield.c
+++ b/src/bitfield/bitfield.c
@@ -69,7 +69,7 @@ bool set_bitfield(const uint64_t value, const uint16_t offset,
     }
 
     ArrayOrBytes combined = {
-        whole: value
+        .whole=value
     };
 
     if(BYTE_ORDER == LITTLE_ENDIAN) {


### PR DESCRIPTION
The current implementation works with GCC only. Since we are using this on a project using MSVC I ported it.

Once this pull request is accepted I will continue with the other dependencies of _uds-c_ which struct initializer problems with MSVC as well.

Please let me know if you want something changed.